### PR TITLE
Fix Module Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ pod 'cdTaskQueue'
 
 In your source files, import the library as follows
 ```Swift
-import cdTaskQueue
+import TaskQueue
 ```
+
+Note that the module name (`TaskQueue`) differs from the Podspec name (`cdTaskQueue`).
+
 
 ### [SwiftPM](https://github.com/apple/swift-package-manager/tree/master/Documentation)
 

--- a/cdTaskQueue.podspec
+++ b/cdTaskQueue.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target = '10.0'
   spec.watchos.deployment_target = '3.0'
 
+  spec.module_name = 'TaskQueue'
   spec.source_files = "Sources/*.swift"
 
   spec.requires_arc = true


### PR DESCRIPTION
The module name when building via CocoaPods has been "cdTaskQueue".
When building with Carthage however, it equals "TaskQueue". In order
to make it more easy to import this library for client which itself
will be either managed by Carthage or CocoaPods, the name has been
unified.

The module name for the framework is now "TaskQueue".